### PR TITLE
remove assumption that first column of constraint system is always 1

### DIFF
--- a/src/main/java/relations/objects/LinearCombination.java
+++ b/src/main/java/relations/objects/LinearCombination.java
@@ -38,11 +38,10 @@ public class LinearCombination<FieldT extends AbstractFieldElementExpanded<Field
 
     public FieldT evaluate(final Assignment<FieldT> input) {
         FieldT result = input.get(0).zero();
-        final FieldT one = result.one();
 
         for (int i = 0; i < terms.size(); i++) {
             final long index = terms.get(i).index();
-            final FieldT value = index == 0 ? one : input.get((int) index).mul(terms.get(i).value());
+            final FieldT value = input.get((int) index).mul(terms.get(i).value());
 
             result = result.add(value);
         }


### PR DESCRIPTION
The edited lines were somewhat restrictive to the assumption that the first column of the constraint system is always 1. This does not appear to be necessary (even when the first component of the input vector is 1). The changes here result in equivalent evaluation for the project's example(s) and enables satisfiability for more general constraints systems.

If there is any particular reason for this that I may have overlooked, please let me know.