### PR TITLE
fix fmsm benchmark

### DIFF
--- a/src/main/java/profiler/profiling/FixedBaseMSMProfiling.java
+++ b/src/main/java/profiler/profiling/FixedBaseMSMProfiling.java
@@ -19,7 +19,9 @@ public class FixedBaseMSMProfiling {
     public static void serialFixedBaseMSMG1Profiling(final Configuration config, final long size) {
         final BN254aFr fieldFactory = new BN254aFr(2L);
         final BN254aG1 groupFactory = new BN254aG1Parameters().ONE();
-        final int scalarSize = groupFactory.bitSize();
+        BN254aG1 generatorG1 = groupFactory.random(config.seed(), config.secureSeed());
+
+        final int scalarSize = generatorG1.bitSize();
 
         final Random rand = new Random(System.nanoTime());
         final ArrayList<BN254aFr> scalars = new ArrayList<>();
@@ -32,9 +34,9 @@ public class FixedBaseMSMProfiling {
 
         config.beginLog("FixedBaseMSM");
         config.beginRuntime("FixedBaseMSM");
-        final int windowSize = FixedBaseMSM.getWindowSize((int) size, groupFactory);
+        final int windowSize = FixedBaseMSM.getWindowSize((int) size, generatorG1);
         final List<List<BN254aG1>> multiplesOfBase = FixedBaseMSM
-                .getWindowTable(groupFactory, scalarSize, windowSize);
+                .getWindowTable(generatorG1, scalarSize, windowSize);
         final List<BN254aG1> result = FixedBaseMSM
                 .batchMSM(scalarSize, windowSize, multiplesOfBase, scalars);
         config.endRuntime("FixedBaseMSM");
@@ -46,7 +48,9 @@ public class FixedBaseMSMProfiling {
     public static void serialFixedBaseMSMG2Profiling(final Configuration config, final long size) {
         final BN254aFr fieldFactory = new BN254aFr(2L);
         final BN254aG2 groupFactory = new BN254aG2Parameters().ONE();
-        final int scalarSize = groupFactory.bitSize();
+        BN254aG2 generatorG2 = groupFactory.random(config.seed(), config.secureSeed());
+
+        final int scalarSize = generatorG2.bitSize();
 
         final Random rand = new Random(System.nanoTime());
         final ArrayList<BN254aFr> scalars = new ArrayList<>();
@@ -61,7 +65,7 @@ public class FixedBaseMSMProfiling {
         config.beginRuntime("FixedBaseMSM");
         final int windowSize = FixedBaseMSM.getWindowSize((int) size, groupFactory);
         final List<List<BN254aG2>> multiplesOfBase = FixedBaseMSM
-                .getWindowTable(groupFactory, scalarSize, windowSize);
+                .getWindowTable(generatorG2, scalarSize, windowSize);
         final List<BN254aG2> result = FixedBaseMSM
                 .batchMSM(scalarSize, windowSize, multiplesOfBase, scalars);
         config.endRuntime("FixedBaseMSM");
@@ -72,7 +76,9 @@ public class FixedBaseMSMProfiling {
 
     public static void distributedFixedBaseMSMG1Profiling(final Configuration config, final long size) {
         final BN254aG1 groupFactory = new BN254aG1Parameters().ONE();
-        final int scalarSize = groupFactory.bitSize();
+        BN254aG1 generatorG1 = groupFactory.random(config.seed(), config.secureSeed());
+
+        final int scalarSize = generatorG1.bitSize();
 
         final JavaPairRDD<Long, BN254aFr> scalars = FixedBaseMSMGenerator.generateData(config, size);
 
@@ -82,9 +88,9 @@ public class FixedBaseMSMProfiling {
         config.beginLog("FixedBaseMSM");
         config.beginRuntime("FixedBaseMSM");
         final int windowSize = FixedBaseMSM
-                .getWindowSize(size / config.numPartitions(), groupFactory);
+                .getWindowSize(size / config.numPartitions(), generatorG1);
         final List<List<BN254aG1>> multiplesOfBase = FixedBaseMSM
-                .getWindowTable(groupFactory, scalarSize, windowSize);
+                .getWindowTable(generatorG1, scalarSize, windowSize);
         FixedBaseMSM.distributedBatchMSM(
                 scalarSize,
                 windowSize,
@@ -99,7 +105,9 @@ public class FixedBaseMSMProfiling {
 
     public static void distributedFixedBaseMSMG2Profiling(final Configuration config, final long size) {
         final BN254aG2 groupFactory = new BN254aG2Parameters().ONE();
-        final int scalarSize = groupFactory.bitSize();
+        BN254aG2 generatorG2 = groupFactory.random(config.seed(), config.secureSeed());
+
+        final int scalarSize = generatorG2.bitSize();
 
         final JavaPairRDD<Long, BN254aFr> scalars = FixedBaseMSMGenerator.generateData(config, size);
 
@@ -109,9 +117,9 @@ public class FixedBaseMSMProfiling {
         config.beginLog("FixedBaseMSM");
         config.beginRuntime("FixedBaseMSM");
         final int windowSize = FixedBaseMSM
-                .getWindowSize(size / config.numPartitions(), groupFactory);
+                .getWindowSize(size / config.numPartitions(), generatorG2);
         final List<List<BN254aG2>> multiplesOfBase = FixedBaseMSM
-                .getWindowTable(groupFactory, scalarSize, windowSize);
+                .getWindowTable(generatorG2, scalarSize, windowSize);
         FixedBaseMSM.distributedBatchMSM(
                 scalarSize,
                 windowSize,


### PR DESCRIPTION
In the original fixed base MSM G1 and G2 profiling code, the code involving Java’s BigInteger.bitSize() is tricky

```
final BN254aG1 groupFactory = new BN254aG1Parameters().ONE();
final int scalarSize = groupFactory.bitSize();
```

Because of Java BigInteger property, the bitSize of groupFactory here is 1 instead of 254. Therefore, we should first generate a random BN254G1/G2 generator using groupFactory, then use the bitSize of the generator.